### PR TITLE
Fixed typo in as-inline-block

### DIFF
--- a/less/routines.less
+++ b/less/routines.less
@@ -48,7 +48,7 @@
 .no-overflow {overflow: hidden;}
 .no-display {display: none;}
 .as-block {display: block; float: none !important;}
-.as-inline-block {display: inline-blockblock;}
+.as-inline-block {display: inline-block;}
 
 .nlm {margin-left: 0 !important;}
 .nrm {margin-right: 0 !important;}


### PR DESCRIPTION
Just a typo fix.
Thank you for this great css!
