### PR TITLE
Adds transparent border for the hover-fix

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -53,6 +53,8 @@ table {
                 padding: 3px 10px;
                 border-right: 1px #ddd solid;
                 border-bottom: 1px #ddd solid;
+                border-left: 1px transparent solid;
+                border-top: 1px transparent solid;
                 box-sizing: border-box;
 
                 &.right {


### PR DESCRIPTION
This prevents the table layout from "jumping" when you hover over a table row that has the hover style

Related to https://github.com/olton/Metro-UI-CSS/issues/74
