### PR TITLE
Updates to pagecontrol.js

### DIFF
--- a/javascript/pagecontrol.js
+++ b/javascript/pagecontrol.js
@@ -16,7 +16,7 @@
                 e.preventDefault();
                 var $a = $(this);
                 if (!$a.parent('li').hasClass('active')) {
-                    $frames.hide();
+                    $this.find(".frames .frame").hide();
                     $ul.find("li").removeClass("active");
                     var target = $($a.attr("href"));
                     target.show();


### PR DESCRIPTION
Fixed issue where pages/frames added with JS aren't hidden after init when switching pages.
Now, we get a fresh set of frames to be hidden before switching pages.
