### PR TITLE
Fix for events on dropdown menu items.

### DIFF
--- a/javascript/dropdown.js
+++ b/javascript/dropdown.js
@@ -18,6 +18,7 @@
             selectors.on('click', function(e){
                 //e.stopPropagation();
                 //$("[data-role=dropdown]").removeClass("active");
+            	if($(e.originalEvent.target).parent().is("[data-role]")) e.stopPropagation();
 
                 clearDropdown();
                 $(this).parents("ul").css("overflow", "visible");


### PR DESCRIPTION
Fixed issue with dropdown.js where events bound to menu items do not work because of the e.stopPropagation() in dropdown.js. 

By removing this behaviour and being more specific in the way in which dropdowns are cleared by $('html').on('click'), events now work on dropdown menu items.
