### PR TITLE
Update to dropdown.js - Initializing dropdowns loaded via Ajax. (Re-initializing exisitng dropdowns)

### DIFF
--- a/javascript/dropdown.js
+++ b/javascript/dropdown.js
@@ -36,7 +36,7 @@
                 //$(this).children(".dropdown-menu").hide();
             });
             $('html').on("click", function(e){
-            	if($(e.originalEvent.target).parents('[data-role="dropdown"]').length == 0)
+            	if(e.originalEvent && $(e.originalEvent.target).parents('[data-role="dropdown"]').length == 0)
             		clearDropdown();
             });
         };


### PR DESCRIPTION
Case:
Dropdown.js currently runs initSelectors automatically on page load. This is fine if all HTML markup for dropdowns exist in the DOM. Suppose i wanted to load a page via ajax that contained one or more dropdown menus? 

Calling 

```
$('[data-role="dropdown"]').each(function () {
    $(this).Dropdown();
});
```

again would cause a double binding of the dropdown callback to already existing menus. This causes them to open and close immediately. By first removing the click callback for the dropdown (if any) it allows rebinding without any adverse effects. So we can now load menus via ajax, and initialize them all in one go without breaking previously initialized menus.

Also namespaced the 'click' binding for the dropdown so it would not affect other click events (if any)

Also added missing semicolons to the file. I'm a little O.C.D. about code. :)
