### PR TITLE
Updated for HTML 5 Standard

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -277,6 +277,7 @@
 .input-control > input[type=email],
 .input-control > input[type=url],
 .input-control > input[type=phone],
+.input-control > input[type=tel],
 .input-control > input[type=password],
 .input-control > input[type=number],
 .input-control > input[type=time],
@@ -308,6 +309,7 @@
 .input-control > input[type=email]::-ms-clear,
 .input-control > input[type=url]::-ms-clear,
 .input-control > input[type=phone]::-ms-clear,
+.input-control > input[type=tel]::-ms-clear,
 .input-control > input[type=number]::-ms-clear,
 .input-control > input[type=time]::-ms-clear {
     display: none;
@@ -331,6 +333,7 @@
         input[type=password]:not(:focus),
         input[type=email]:not(:focus),
         input[type=phone]:not(:focus),
+        input[type=tel]:not(:focus),
         input[type=number]:not(:focus),
         input[type=time]:not(:focus),
         input[type=url]:not(:focus) {
@@ -343,6 +346,7 @@
         input[type=password]:focus,
         input[type=email]:focus,
         input[type=phone]:focus,
+        input[type=tel]:focus,
         input[type=number]:focus,
         input[type=time]:focus,
         input[type=url]:focus {
@@ -356,6 +360,7 @@
         input[type=password]:not(:focus),
         input[type=email]:not(:focus),
         input[type=phone]:not(:focus),
+        input[type=tel]:not(:focus),
         input[type=number]:not(:focus),
         input[type=time]:not(:focus),
         input[type=url]:not(:focus) {


### PR DESCRIPTION
Added Support for <input type="tel"> as defined in official [HTML5 standard](http://www.w3.org/html/wg/drafts/html/master/forms.html#telephone-state-%28type=tel%29). To fix this issue (https://github.com/olton/Metro-UI-CSS/issues/222).
