### PR TITLE
Adding the ability to pause and resume live tiles.

### DIFF
--- a/js/metro-live-tile.js
+++ b/js/metro-live-tile.js
@@ -39,14 +39,18 @@
                 'height': element.height()
             };
 
-            this._start();
+            this.start();
         },
 
-        _start: function(){
+        start: function(){
             var that = this;
             this._interval = setInterval(function(){
                 that._animate();
             }, this.options.period);
+        },
+        
+        stop: function(){
+            clearInterval(this._interval);
         },
 
         _animate: function(){
@@ -150,7 +154,3 @@
 $(function () {
     $('[data-role=live-tile], [data-role=live]').livetile();
 });
-
-function reinitLives(){
-    $('[data-role=live-tile], [data-role=live]').livetile();
-}


### PR DESCRIPTION
This is a simple adjustment to the live-tiles to allow the ability to
pause and resume the animations. This also removes the reinitLives()
function which was in the global scope and didn’t clear the setInterval
timer.

I decided to add this because I needed a way to pause the tiles while on-hover ... Also for performance reasons I needed tiles to pause while outside of the viewport.

Now a tile can be pause by using:
el.livetile('stop');

and restarted with:
el.livetile('start');
