### PR TITLE
metro-pull.js moved before metro-initiator.js

### DIFF
--- a/compress/compressor.js
+++ b/compress/compressor.js
@@ -43,8 +43,8 @@ var modules = [
     module_path+'metro-streamer.js',
     module_path+'metro-scroll.js',
     module_path+'metro-stepper.js',
-    module_path+'metro-initiator.js',
-    module_path+'metro-pull.js'
+    module_path+'metro-pull.js',
+    module_path+'metro-initiator.js'
 
 ];
 


### PR DESCRIPTION
It was causing calls to pullmenu() even before it was loaded.
