### PR TITLE
carousel #178 and pt 2 of #375

### DIFF
--- a/js/metro-carousel.js
+++ b/js/metro-carousel.js
@@ -124,7 +124,7 @@
             // don't calculate transition for null, it will just be a show()
             if (this.slideIndex() !== null)
                 // If slideIndex is out of bounds continue to scroll cyclically
-                if ((newIndex > this.slideIndex() || newIndex < 0) && newIndex < this._slides.length) {
+                if (newIndex > this.slideIndex()) {
                     outPosition = -this.element.width();
                 } else {
                     outPosition = this.element.width();


### PR DESCRIPTION
#375 fixed option usage and loading from html data- properties
#178 Added slideIndex initial setting (set to a slide index, or 'auto' will start at 0 for direction:right and _slides.length -1 for direction:left).

Added slideIndex and pageCount widget properties.

Fixed issue where resize would show clipped images because they were not hidden at the end of animations.

Consolidated slide and marker duplicated logic into existing _slideToSlide method to allow easy one point access from slideIndex property.
