### PR TITLE
carousel #178 and pt 2 of #375

### DIFF
--- a/docs/js/metro/metro-carousel.js
+++ b/docs/js/metro/metro-carousel.js
@@ -168,9 +168,10 @@
 
         slideIndex: function (index) {
             if (index !== undefined) {
+                var trigger = index !== this._slideIndex;
                 this._slideIndex = this._slideToSlide(index);
-                if (index === this._slideIndex) return;
-                this.element.trigger('slidechange', this._slideIndex);
+                if (trigger)
+                    this.element.trigger('slidechange', this._slideIndex);
             }
             else
                 return this._slideIndex;


### PR DESCRIPTION
#375 fixed option usage and loading from html data- properties
#178 Added slideIndex initial setting (set to a slide index, or 'auto' will start at 0 for direction:right and _slides.length -1 for direction:left).

Added slideIndex and pageCount widget properties.

Fixed issue where resize would show clipped images because they were not hidden at the end of animations.

Consolidated slide and marker duplicated logic into existing _slideToSlide method to allow easy one point access from slideIndex property.
