### PR TITLE
fixed unhandled exception in _hide function

### DIFF
--- a/js/metro-notify.js
+++ b/js/metro-notify.js
@@ -88,7 +88,7 @@
 			if(this._notify != undefined) {
 				var self = this;
         	   		this._notify.hide('slow', function() {
-					self.remove();
+					$(this).remove();
 					_notifies.splice(_notifies.indexOf(self._notify), 1);
 				});
 				return this;


### PR DESCRIPTION
_hide function: in closure "this" points to the raw html object and doesn't have requested methods. Must point to the _notify object. 
Reproduced in IE11
