### PR TITLE
Update _hide() method in js/metro-notify.js

### DIFF
--- a/js/metro-notify.js
+++ b/js/metro-notify.js
@@ -83,12 +83,13 @@
 		},
 		
 		_hide: function() {
-			this.clear();
+		    this.clear();
 		
-			if(this._notify != undefined) {
-        	   	this._notify.hide('slow', function() {
-					this.remove();
-					_notifies.splice(_notifies.indexOf(this._notify), 1);
+		    if (this._notify != undefined) {
+		        var notifyIndex = _notifies.indexOf(this._notify);
+			    this._notify.hide('slow', function () {
+			                _notifies[notifyIndex].remove();
+					_notifies.splice(notifyIndex, 1);
 				});
 				return this;
 			} else {


### PR DESCRIPTION
I was getting an error when "this._notify.remove();" was called (line: 90).
