### PR TITLE
Fix effect: "none" option for dropdown

### DIFF
--- a/docs/js/metro/metro-dropdown.js
+++ b/docs/js/metro/metro-dropdown.js
@@ -45,7 +45,7 @@
             switch (this.options.effect) {
                 case 'fade': $(el).fadeIn('fast'); break;
                 case 'slide': $(el).slideDown('fast'); break;
-                default: $(el).hide();
+                default: $(el).show();
             }
             this._trigger("onOpen", null, el);
         },


### PR DESCRIPTION
When clicking with effect: "none", the dropdown doesn't appear.
