### PR TITLE
Slider change events not fired until mouseup

### DIFF
--- a/js/metro-slider.js
+++ b/js/metro-slider.js
@@ -95,6 +95,7 @@
 
             $(document).mousemove(function (event) {
                 that._movingMarker(event);
+                element.trigger('changed', that.options.position);
                 if (!element.hasClass('permanent-hint')) {
                     hint.css('display', 'block');
                 }


### PR DESCRIPTION
This change fires events as the slider is moving so you can use this control to edit in realtime.