### PR TITLE
Update metro-datepicker.js

### DIFF
--- a/js/metro-datepicker.js
+++ b/js/metro-datepicker.js
@@ -85,6 +85,7 @@
                     //console.log(d, d0);
                     _calendar.calendar('setDate', d0);
                     to.children("input[type=text]").val(d);
+                    that.element.data('date', d0);
                     that.options.selected(d, d0);
                     that._hide();
                 }


### PR DESCRIPTION
Updated the _calendar.calendar::click so that the date can be retrieved in a universal format via the data('date') attribute of the datepicker.

This is useful if you need to copy the selected date from one datepicker to another, for example, because the date string in the input varies according to the data-format attribute.