### PR TITLE
Create a badge option for metro class

### DIFF
--- a/css/metro-bootstrap.css
+++ b/css/metro-bootstrap.css
@@ -10667,3 +10667,21 @@ a {
   background-image: linear-gradient(-45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-size: 40px 40px;
 }
+/* Create a badge option for metro class */
+.metro .badge {
+  font-family: 'Segoe UI Semibold_', 'Open Sans Bold', Verdana, Arial, Helvetica, sans-serif;
+  display: inline-block;
+  min-width: 10px;
+  padding: 3px 5px;
+  font-size: 12px;
+  line-height: 1.2;
+  color: #fff !important;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  background-color: #1274A3;
+  border-radius: 10px;
+}
+.metro .badge:empty {
+  display: none;
+}


### PR DESCRIPTION
Due to restrictions on the use of the badge class (available only in tile class).