### PR TITLE
Using variable value for .body-text

### DIFF
--- a/less/typography.less
+++ b/less/typography.less
@@ -134,8 +134,8 @@
     #font > .segoe;
     #font > .normal;
     .text-rest-state;
-    font-size: 11pt;
-    line-height: 15pt;
+    font-size: @baseFontSize;
+    line-height: @baseLineHeight;
     letter-spacing: 0.02em;
 }
 


### PR DESCRIPTION
lists and other stuff retrieve their font-size from .body-text which does not use the `@baseFontSize` and `@baseLineHeight`