### PR TITLE
Change default font from serif to sans-serif

### DIFF
--- a/docs/typography.html
+++ b/docs/typography.html
@@ -39,15 +39,15 @@
                 </thead>
                 <tr>
                     <td>@fontName:</td>
-                    <td>"Segoe UI", "Open Sans", serif;</td>
+                    <td>"Segoe UI", "Open Sans", sans-serif;</td>
                 </tr>
                 <tr>
                     <td>@fontNameLight:</td>
-                    <td>"Segoe UI Light", "Open Sans Light", serif;</td>
+                    <td>"Segoe UI Light", "Open Sans Light", sans-serif;</td>
                 </tr>
                 <tr>
                     <td>@fontNameBold:</td>
-                    <td>"Segoe UI Bold", "Open Sans Bold", serif;</td>
+                    <td>"Segoe UI Bold", "Open Sans Bold", sans-serif;</td>
                 </tr>
             </table>
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -2,9 +2,9 @@
 @subunitSize:           5px;
 
 //Typo
-@fontName: "Segoe UI", "Open Sans", serif;
-@fontNameLight: "Segoe UI Light", "Open Sans Light", serif;
-@fontNameBold: "Segoe UI Bold", "Open Sans Bold", serif;
+@fontName: "Segoe UI", "Open Sans", sans-serif;
+@fontNameLight: "Segoe UI Light", "Open Sans Light", sans-serif;
+@fontNameBold: "Segoe UI Bold", "Open Sans Bold", sans-serif;
 
 @baseFontSize: .875rem;
 @secondTextFontSize: .75rem;


### PR DESCRIPTION
## Hangul + serif
I use hangul. (Hangul is korean character)
Hangul is not included in Segoe UI or Open sans font, so Hangul use default font.
If default font is serif, hangul doesn't look likes metro design.

### serif
![metro-font-before](https://cloud.githubusercontent.com/assets/971476/8396128/abaec94a-1dd3-11e5-8fc6-9a81f8f9647c.png)

### sans-serif
![metro-font-after](https://cloud.githubusercontent.com/assets/971476/8396129/adeb4cd8-1dd3-11e5-8d96-f0af9391ee3b.png)


## History
When metro ui css v2, library use san-serif as default font.
```
@segoeFontFamily: 'Segoe UI_', 'Open Sans', Verdana, Arial, Helvetica, sans-serif;
```

Now, library use serif as default font.
```
@fontName: "Segoe UI", "Open Sans", serif;
```

I can't understand why you change sans-serif to serif. 
If there is no special reason, could you change default font to sans-serif?