### PR TITLE
Update inputs.js

### DIFF
--- a/js/widgets/inputs.js
+++ b/js/widgets/inputs.js
@@ -34,6 +34,9 @@ $.widget("metro.input", {
         var element = this.element;
         var input = element.find("input");
         var placeholder = element.find(".placeholder");
+        
+        if (input.val() !== "")
+            placeholder.css({display: "none"});
 
         input.on("blur", function(){
             if (input.val() !== "") {


### PR DESCRIPTION
When you send form with this inputs and got response with error, page reload with text inside inputs and placeholder is visible. This make the placeholder invisible when page load with some text inside it.

![error](https://cloud.githubusercontent.com/assets/13621655/9034769/a385ca64-39d2-11e5-865e-0eab98ac0881.png)