### PR TITLE
Error on showing day names when data-locale="it"

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -156,8 +156,8 @@ window.METRO_LOCALES = {
             'Gen', ' Feb', 'Mar', 'Apr', 'Mag', 'Giu', 'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'
         ],
         days: [
-            'Lunedì', 'Martedì', 'Mercoledì', 'Giovedì', 'Venerdì', 'Sabato', 'Domenica',
-            'Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab', 'Dom'
+            'Domenica', 'Lunedì', 'Martedì', 'Mercoledì', 'Giovedì', 'Venerdì', 'Sabato', 
+            'Dom', 'Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab'
         ],
         buttons: [
             "Oggi", "Cancella", "Cancel", "Help", "Prior", "Next", "Finish"


### PR DESCRIPTION
1) When I set data-locale="it" in the calendar, it's showing Sunday = Lunedì, Monday = Martedì .. 
in italian language, Monday = Lunedì, Tuesday = Martedì ..

2) I've changed line 159 and 160 of global.js

3) Screenshot of the error http://pasteboard.co/1uH6IWXQ.png