### PR TITLE
Added swich to allow override of keypad key size.

### DIFF
--- a/js/widgets/keypad.js
+++ b/js/widgets/keypad.js
@@ -7,6 +7,7 @@ $.widget( "metro.keypad" , {
         shuffle: false,
         length: false,
         keys: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+        size: 32,
         onKey: function(key){},
         onChange: function(value){}
     },
@@ -51,7 +52,7 @@ $.widget( "metro.keypad" , {
         }
 
         keypad.html('').css({
-            width: keys_length / 4 * 32 + (keys_length / 4 + 1) * 2 + 2
+            width: keys_length / 4 * o.size + (keys_length / 4 + 1) * 2 + 2
         });
 
         keys.map(function(i){


### PR DESCRIPTION
Hi,

This is a simple patch to add an option to override the size of the keys in `.keypad` when applying custom css. Found this an issue when developing a web app for home automation, the keypad simply wasn't git enough on the displays. This allows the developer to add a `data-size=96` option to the keypad div.

I imagine there's possibly a need to change some docs to support this, and possibly a more clever way of handling the css than just 'copy-paste inline, and edit' as I've done it. Let me know what you think?

Cheers,
LadyC.