### PR TITLE
added setDate method on datepicker

### DIFF
--- a/js/widgets/datepicker.js
+++ b/js/widgets/datepicker.js
@@ -1,7 +1,7 @@
 $.widget("metro.datepicker", {
 
     version: "3.0.0",
-
+    //test-commen3
     options: {
         format: "yyyy.mm.dd",
         preset: false,
@@ -108,9 +108,10 @@ $.widget("metro.datepicker", {
             maxDate: o.maxDate,
             scheme: o.scheme,
             dayClick: function(d, d0){
-                //console.log(d, d0);
+                // console.log(d, d0);
                 _calendar.calendar('setDate', d0);
                 that.element.children("input[type=text]").val(d);
+                // debugger;
                 that.element.children("input[type=text]").trigger('change', d0);
                 that.element.children("input[type=text]").blur();
                 that._hide();
@@ -170,5 +171,32 @@ $.widget("metro.datepicker", {
 
     _setOption: function(key, value){
         this._super('_setOption', key, value);
+    },
+
+    //sets the date on the datepicker
+    setDate : function(date) {
+
+      if($.isArray(date)) {
+          //TODO: handle multi-selected dates
+      }
+
+      //TODO: test for IE support
+
+      var input = this.element.find('input');
+
+      //retrieve calendar instance
+      //and get associated dom element
+      var calInst = this._calendar.data('metro-calendar');
+      var calEl = calInst.element;
+
+      //clear the date storage
+      calEl.data('_storage', []);
+
+      //set date on calendar
+      this._calendar.calendar('setDate', date);
+
+      date = this._calendar.calendar('getDate');
+      input.val(date);
+
     }
 });


### PR DESCRIPTION
First of all...good work.

Was using this lib and noticed that there was no way to set date on a datepicker. Thought this would be a major setback for those using this lib. And I was a bit skeptical about the lack of this feature until I saw [this](http://forum.metroui.org.ua/viewtopic.php?id=350&search_hl=1564534504)

Few pain points that needs addressing. You probably need an environment setup guide. I spent a whole day just getting this right. I don't know if I got this right, but you can probably review this on the `calendar-branch` I've got from your forked-repo.

Usage
-
```
$('.datepicker').datepicker('setDate', somedate);
```