### PR TITLE
publishing as an npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
     "author": "Sergey Pimenov",
-    "name": "metro",
+    "name": "metro-ui",
     "version": "3.0.13",
+	"main": "build/js/metro.js",
     "description": "The front-end framework for developing responsive, mobile projects on the web in Windows Metro Style.",
     "keywords": [
         "css",


### PR DESCRIPTION
hi, @olton . we wanted to use Metro-UI-CSS as one of the dependencies in an npm-based project, so we published it onto npmjs.com. what is your account on npmjs.com? we hope to transfer ownership back to you if you don't mind.