### PR TITLE
Add prepend-icon support on select tags + treeview more options

### DIFF
--- a/js/widgets/treeview.js
+++ b/js/widgets/treeview.js
@@ -295,23 +295,36 @@ $.widget( "metro.treeview" , {
         if (ul.length === 0) {
             ul = $("<ul/>").appendTo(parent ? parent : element);
         }
+        
+        li = $("<li/>");
+        if (data && data.className) {
+            li.addClass(data.className);
+        }
+        
+        if (data && data.before) {
+            data.before.before(li);
+        } else {
+            li.appendTo(ul);
+        }
 
-        li = $("<li/>").appendTo( ul );
-
-        if (data !== undefined) {
-            if (data.tagName !== undefined) {
-                leaf = $("<"+data.tagName+"/>").addClass("leaf").appendTo(li);
-            } else {
-                leaf = $("<span/>").addClass("leaf").appendTo(li);
-            }
+        if (data !== undefined && data.tagName !== undefined) {
+            leaf = $("<"+data.tagName+"/>").addClass("leaf").appendTo(li);
         } else {
             leaf = $("<span/>").addClass("leaf").appendTo(li);
         }
-
+        
+        name = '<span class="name">' + name + '</span>';
+        
+        if (data !== undefined && data.icon !== undefined) {
+            name = '<span class="icon mif-' + data.icon + '"></span>' + name;
+        }
+        
         leaf.html(name);
 
         if (data !== undefined) {
             $.each(data, function(key, value){
+                if (key == "before")
+                    return;
                 li.attr("data-"+key, value);
             });
             if (data.mode !== undefined) {

--- a/less/inputs.less
+++ b/less/inputs.less
@@ -47,13 +47,13 @@
 			line-height: 1;
 			position: absolute;
 			top: 50%;
-            margin-top: -12px;
+      margin-top: -12px;
 			left: 4px;
 			z-index: 2;
 			color: @grayLight;
 		}
 
-		.prepend-icon ~ input {
+		.prepend-icon ~ input, .prepend-icon ~ select {
 			padding-left: 30px;
 		}
 	}


### PR DESCRIPTION
**Prepend-icon**
A small fix to allow prepend-icon on select tag with the logic used on input.

**Tree-view**
On treeview I added "before" option that allow us to specify where we want the leaf and not at the end.
Plus the option to directly add an icon to a leaf.
Example with one of my functions:
````
addLeaf: function( ev )
{
      var node = this.treeview.addLeaf(
        $( ev.currentTarget ).parent().parent()
        , "New " + $( ev.currentTarget ).attr( 'data-target' ) // can be parent or child
        , {
          before     : $( ev.currentTarget )
          ,icon      : "link"
          ,className : $( ev.currentTarget ).attr( 'data-target' )
        } );
      node.attr( 'data-type', 'url' );
}