### PR TITLE
Add before and icon on treeview + prepend-icon on select + readonly on file input

### DIFF
--- a/js/widgets/inputs.js
+++ b/js/widgets/inputs.js
@@ -60,7 +60,11 @@ $.widget("metro.input", {
     _createInputFile: function(){
         var element = this.element;
         var wrapper, button, input;
-        wrapper = $("<input type='text' class='input-file-wrapper' readonly style='z-index: 1; cursor: default;'>");
+        wrapper = $("<input type='text' class='input-file-wrapper' style='z-index: 1; cursor: default;'>");
+        if (element.attr( 'data-readonly' ) != "false") {
+          wrapper.attr('readonly', true);
+        }
+        
         button = element.children('.button');
         input = element.children('input[type="file"]');
         input.css('z-index', 0);

--- a/js/widgets/treeview.js
+++ b/js/widgets/treeview.js
@@ -295,24 +295,38 @@ $.widget( "metro.treeview" , {
         if (ul.length === 0) {
             ul = $("<ul/>").appendTo(parent ? parent : element);
         }
+        
+        li = $("<li/>");
+        if (data && data.className) {
+            li.addClass(data.className);
+        }
+        
+        if (data && data.before) {
+            data.before.before(li);
+        } else {
+            li.appendTo(ul);
+        }
 
-        li = $("<li/>").appendTo( ul );
-
-        if (data !== undefined) {
-            if (data.tagName !== undefined) {
-                leaf = $("<"+data.tagName+"/>").addClass("leaf").appendTo(li);
-            } else {
-                leaf = $("<span/>").addClass("leaf").appendTo(li);
-            }
+        if (data !== undefined && data.tagName !== undefined) {
+            leaf = $("<"+data.tagName+"/>").addClass("leaf").appendTo(li);
         } else {
             leaf = $("<span/>").addClass("leaf").appendTo(li);
         }
-
+        
+        if (data !== undefined && data.icon !== undefined) {
+            name = '<span class="icon mif-' + data.icon + '"></span>' + name;
+        }
+        else {
+            name = '<span class="name">' + name + '</span>';
+        }
+        
         leaf.html(name);
 
         if (data !== undefined) {
             $.each(data, function(key, value){
-                li.attr("data-"+key, value);
+              if (key == "before")
+                  return;
+              li.attr("data-"+key, value);
             });
             if (data.mode !== undefined) {
                 switch (data.mode) {

--- a/less/inputs.less
+++ b/less/inputs.less
@@ -53,7 +53,7 @@
 			color: @grayLight;
 		}
 
-		.prepend-icon ~ input {
+		.prepend-icon ~ input, .prepend-icon ~ select {
 			padding-left: 30px;
 		}
 	}
@@ -238,6 +238,10 @@ input, select, textarea {
 				border-color: darken(@inputHoverState, 10%);
 			}
 		}
+    
+    input[type=text] {
+      padding-right: 50px;
+    }
 	}
 }
 


### PR DESCRIPTION
**Prepend-icon**
A small fix to allow prepend-icon on select tag with the logic used on input.
![select-prepend-icon](https://cloud.githubusercontent.com/assets/1068709/13949616/56e3bea4-f026-11e5-8a8b-359a0d9a8620.png)

**Readonly as an option + padding**
I wanted to create an file input and being able to type inside directly.
A padding to avoid the text behind the button, and an option to allow this (by default it's set to true, same as current version).

It can be useful in some case.

Here on my screenshot, I can see the file extension. But without the padding you can't it's behind the file icon button.
![file-input-not-readonly](https://cloud.githubusercontent.com/assets/1068709/13949711/e428f8ba-f026-11e5-9772-6c952b2da085.png)

**Tree-view**
On treeview I added "before" option that allow us to specify where we want the leaf and not at the end.
Plus the option to directly add an icon to a leaf.

This feature was useful in my case to add a leaf before the "+ Add child/parent" without re-writing or managing node after add.

Example with one of my functions:

```
addLeaf: function( ev )
{
      var node = this.treeview.addLeaf(
        $( ev.currentTarget ).parent().parent()
        , "New " + $( ev.currentTarget ).attr( 'data-target' ) // can be parent or child
        , {
          before     : $( ev.currentTarget )
          ,icon      : "link"
          ,className : $( ev.currentTarget ).attr( 'data-target' )
        } );
      node.attr( 'data-type', 'url' );
}
```

Screenshot of my editor
![treeview-add-before](https://cloud.githubusercontent.com/assets/1068709/13949644/8e451348-f026-11e5-86dd-cb186eb4c5e7.png)
