### PR TITLE
Fixed problem with active items within a Sub Menu

### DIFF
--- a/less/sidebar.less
+++ b/less/sidebar.less
@@ -190,7 +190,7 @@
         }
 	}
 
-	li li:not(:hover) {
+	li li:not(:hover) li:not(.active) {
 		color: @dark ;
 
 		a {


### PR DESCRIPTION
When the list item is active, ```.sidebar2 li li:not(:hover) a ``` would still change the background to white.
This is just a little fix to stop that from happening.