### PR TITLE
Adding class attribute to buttons in Dialogs

### DIFF
--- a/js/widgets/dialog.js
+++ b/js/widgets/dialog.js
@@ -477,7 +477,7 @@ var dialog = {
             $.each(data.actions, function(){
                 var item = this;
 
-                button = $("<button>").attr("type", "button").addClass("button").html(item.title);
+                button = $("<button>").attr("type", "button").addClass("button").addClass(item.class).html(item.title);
 
                 if (item.cls !== undefined) {
                     button.addClass(item.cls);


### PR DESCRIPTION
Dynamically generated dialog's buttons can not have special class attributes other than '.button' class. With this pull request people can add class attributes like 'bg-red', 'place-left' etc. to their buttons by using 'class' parameter in their constructor parameters.