### PR TITLE
Remove the delayed execution of href

### DIFF
--- a/js/widgets/tile.js
+++ b/js/widgets/tile.js
@@ -211,12 +211,6 @@ $.widget( "metro.tile" , {
             $(this).addClass("tile-transform-"+transform);
 
             //console.log(transform);
-
-            if (element[0].tagName === 'A' && element.attr('href')) {
-                setTimeout(function(){
-                    document.location.href = element.attr('href');
-                }, 500);
-            }
         });
 
         element.on(event_up, function(){


### PR DESCRIPTION
Executing the href via document.location.href is not a good idea. In fact, the href is executed twice: Once for the default DOM-Event for a Hyperlink and then again delayed by the above code.

It has the following (negative) effects:
- If you have a link that does not change the page but opens an application (e.g. mailto:), then it gets opened twice.
- If you configure your href to another target (e.g. target="_blank"), then the page location changes AND a new tab is opened.

I suggest to let the A-href do it's thing without interfering (merely for an animation to run).