### PR TITLE
Slider: Fix marker position when not visible

### DIFF
--- a/source/components/slider/slider.js
+++ b/source/components/slider/slider.js
@@ -419,8 +419,8 @@ var Slider = {
             if (slider_visible) {
                 marker.css('top', length - this.pixel);
             } else {
-                marker.css('top', this.percent + "%");
-                marker.css('margin-top', this.percent === 0 ? 0 : -1 * marker_size / 2);
+                marker.css('top', (100 - this.percent) + "%");
+                marker.css('margin-top', marker_size / 2);
             }
             complete.css('height', this.percent+"%");
         } else {


### PR DESCRIPTION
When changing value of an invisible vertical slider it then showed with a marker at an inverted position. This commit fix it.