### PR TITLE
Fix the use of accuracy option in _correct()

### DIFF
--- a/source/components/slider/slider.js
+++ b/source/components/slider/slider.js
@@ -319,7 +319,7 @@ var Slider = {
             return value;
         }
 
-        value = Math.floor(value / accuracy) * accuracy + Math.round(value % accuracy / accuracy) * accuracy;
+        value = Math.round(value/accuracy)*accuracy;
 
         if (value < min) {
             value = min;


### PR DESCRIPTION
The slider value stepping behavior seems to be incorrect when I use custom min/max/accuracy setting. Please see an example [here](https://codepen.io/hokiedsp/pen/ZEzdPWb). When I set `min=-4`, `max=4`, `accuracy=0.04` I expect it to step on the values -4, -3.96, -3.92, ... -0.04, 0, 0.04, ... 3.96, 4. But instead, the current implementation steps: -4, -3.04, -2.04, -1.04, 0, 1.04, 2.04, 3.04, 4.
The keyboard callback appears to be configured as the former in `Metro.events.keydown` callback.

Anyway, my pull request should fix this (if what I have in my mind is what is intended).
