### PR TITLE
added fix for appbar

### DIFF
--- a/source/components/app-bar/app-bar.js
+++ b/source/components/app-bar/app-bar.js
@@ -148,6 +148,8 @@ var AppBar = {
         var hamburger = element.find(".hamburger");
 
         menu.slideUp(o.duration, function(){
+			$('body').removeClass('overflow-hidden');
+			element.removeClass('scrollable');
             menu.addClass("collapsed");
             hamburger.removeClass("active");
         });
@@ -159,6 +161,8 @@ var AppBar = {
         var hamburger = element.find(".hamburger");
 
         menu.slideDown(o.duration, function(){
+			$('body').addClass('overflow-hidden');
+			element.addClass('scrollable');
             menu.removeClass("collapsed");
             hamburger.addClass("active");
         });

--- a/source/components/app-bar/app-bar.less
+++ b/source/components/app-bar/app-bar.less
@@ -254,3 +254,14 @@
 .h-ab {
     height: ~"calc(100% - 52px)";
 }
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+header:not(.app-bar-expand) {
+  &.scrollable {
+    max-height: 100%;
+    overflow: scroll;
+  }
+}


### PR DESCRIPTION
I created a small fix for the appbar on a mobile device.
If you have an appbar with a lot of entries and/or subentries it is not usable on mobile devices, because there is no possibility to scroll.

I currently have this issue [here](https://morrisjdev.github.io/ng-metro4/#/)

The fix I made is simple:
I created a class for the header that makes it scrollable and a class that hides the overflow of the bottom. Both class will be added on open and removed on close of the appbar.

I don't know if their is a utility class for overflow-hidden that could be used, but I didn't find one.

What do you think about this fix?