### PR TITLE
Fix the use of accuracy option in _correct() (fixed PR to 4.3.3)

### DIFF
--- a/source/components/slider/slider.js
+++ b/source/components/slider/slider.js
@@ -319,7 +319,7 @@ var Slider = {
             return value;
         }
 
-        value = Math.floor(value / accuracy) * accuracy + Math.round(value % accuracy / accuracy) * accuracy;
+        value = Math.round(value/accuracy)*accuracy;
 
         if (value < min) {
             value = min;


### PR DESCRIPTION
This is a retry of my earlier PR to the latest release branch (4.3.3). 

Here is my original note:

> The slider value stepping behavior seems to be incorrect when I use custom min/max/accuracy setting. Please see an example here. When I set min=-4, max=4, accuracy=0.04 I expect it to step on the values -4, -3.96, -3.92, ... -0.04, 0, 0.04, ... 3.96, 4. But instead, the current implementation steps: -4, -3.04, -2.04, -1.04, 0, 1.04, 2.04, 3.04, 4.
> The keyboard callback appears to be configured as the former in Metro.events.keydown callback.
> 
> Anyway, my pull request should fix this (if what I have in my mind is what is intended).
> 

@olton - You mentioned "This fix is wrong" in my first PR attempt. Could you elaborate on that? Maybe I'm misinterpreting what "accuracy" variable does. Thanks!