### PR TITLE
Added fill (fc) to metro-colors

### DIFF
--- a/source/colors/fill.less
+++ b/source/colors/fill.less
@@ -1,0 +1,8 @@
+@import (once) "../include/vars";
+
+each(@colorList, {
+    .fc-@{value} {fill: @@value !important;}
+    .fc-@{value}-active {&:active {fill: @@value !important;}}
+    .fc-@{value}-hover {&:hover {fill: @@value !important;}}
+    .fc-@{value}-focus {&:focus {fill: @@value !important;}}
+})

--- a/source/metro-colors.less
+++ b/source/metro-colors.less
@@ -1,5 +1,6 @@
 @import "colors/background";
 @import "colors/foreground";
+@import "colors/fill";
 @import "colors/outline";
 @import "colors/border";
 @import "colors/ribbed";


### PR DESCRIPTION
Included "fc" (fill color) for css fill properties - fits best for SVG path

