### PR TITLE
Replace String.includes() with String.indexOf()

### DIFF
--- a/source/m4q/m4q.js
+++ b/source/m4q/m4q.js
@@ -3047,7 +3047,7 @@ function _setStyle (el, key, val, unit, toInt) {
         if (typeof el[key] !== "undefined") {
             el[key] = val;
         } else {
-            el.style[key] = key === "transform" || key.toLowerCase().includes('color') ? val : val + unit;
+            el.style[key] = key === "transform" || key.toLowerCase().indexOf('color') > -1 ? val : val + unit;
         }
     } else {
         el[key] = val;


### PR DESCRIPTION
In the current version 4.3.7 the method String.includes() is used which is not supported by IE 11.
I have replaced it with String.indexOf() > -1 which is supported and already used at several other places in the code.