### PR TITLE
When there is a container under the appbar, the menu fails

### DIFF
--- a/source/components/app-bar/app-bar.js
+++ b/source/components/app-bar/app-bar.js
@@ -48,6 +48,8 @@
         _createStructure: function () {
             var element = this.element, o = this.options;
             var hamburger, menu, elementColor = Utils.getStyleOne(element, "background-color");
+            var container = element.find('.container');
+            if(container) element = container;
 
             element.addClass("app-bar");
 


### PR DESCRIPTION
When there is a container under the appbar, because Hamburger is not under the container, it will cause problems with the menu display.

