### PR TITLE
[fix bug] Fixed uninitialized variable that prevented select-all in tables

### DIFF
--- a/source/components/table/table.js
+++ b/source/components/table/table.js
@@ -1072,7 +1072,8 @@
                 var checked = $(this).is(":checked");
                 var store_key = o.checkStoreKey.replace("$1", id);
                 var storage = Metro.storage;
-                var data, stored_keys;
+                var data = [];
+		var stored_keys;
 
                 if (o.useCurrentSlice === true) {
                     stored_keys = storage.getItem(store_key, []);


### PR DESCRIPTION
The `data` variable was uninitialized for the `useCurrentSlice == false` case in the `.table-service-select-all` function.  This caused an unhandled exception which prevented using the select-all box.  This pull request initialized this variable as it was before the `useCurrentSlice` update.

Fixes a bug created by the changes made in response to #1778  