### PR TITLE
Update analog-clock.js

### DIFF
--- a/source/components/analog-clock/analog-clock.js
+++ b/source/components/analog-clock/analog-clock.js
@@ -126,7 +126,7 @@
                 const date = datetime();
                 const sec = (date.second() / 60) * 360;
                 const min = (date.minute() / 60) * 360;
-                const hr = (date.hour12() / 12) * 360;
+                const hr = (date.hour12() / 12) * 360 + min/12;
                 const day = date.format("DD", this.locale);
                 const month = date.format("MMM", this.locale);
                 const moon = date.moon();


### PR DESCRIPTION
hour hand moved with minutes too.

At 22h55 the hour hand was pointing 10 instead of almost pointing 11...
I saw in the code that the hour hand was moved accordingly with rounder hours